### PR TITLE
FOIA-6: Truncates Case Citation source data.

### DIFF
--- a/config/default/migrate_plus.migration.foia_iv_statute.yml
+++ b/config/default/migrate_plus.migration.foia_iv_statute.yml
@@ -109,7 +109,16 @@ process:
           source: '@combined'
           index:
             - '1'
-  field_case_citation: field_case_citation
+  field_case_citation_trunc:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: field_case_citation
+    -
+      plugin: substr
+      source: field_case_citation
+      length: 255
+  field_case_citation: field_case_citation_trunc
   field_statute: field_statute
   field_total_num_relied_by_agency:
     -

--- a/docroot/modules/custom/foia_upload_xml/config/install/migrate_plus.migration.foia_iv_statute.yml
+++ b/docroot/modules/custom/foia_upload_xml/config/install/migrate_plus.migration.foia_iv_statute.yml
@@ -101,7 +101,16 @@ process:
           source: '@combined'
           index:
             - '1'
-  field_case_citation: field_case_citation
+  field_case_citation_trunc:
+   -
+     plugin: skip_on_empty
+     method: process
+     source: field_case_citation
+   -
+     plugin: substr
+     source: field_case_citation
+     length: 255
+  field_case_citation: field_case_citation_trunc
   field_statute: field_statute
   field_total_num_relied_by_agency:
     -


### PR DESCRIPTION
Truncates Case Citation source data to prevent errors on import when field exceeds 255 chars.